### PR TITLE
use --version long op for version

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -743,6 +743,7 @@ Here's a list of commonly used options:
   This is particularly useful when displaying output for humans that you might want to hide when running in a script.
 - `-u`, `--user`: User.
   For example, `ps`, `ssh`.
+- `--version`: Version.
 - `-v`: This can often mean either verbose or version.
   You might want to use `-d` for verbose and this for version, or for nothing to avoid confusion.
 


### PR DESCRIPTION
Without this commit, the document mentions the possibility of using
`-v` for version, but doesn't mention the standard long option for
printing the version.  Having `--version` is always better -- it's
unambiguous unlike `-v`, and fits the document's other advice about
preferring long options over short ones.