### PR TITLE
Fix environment variables rules

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -1050,8 +1050,8 @@ So, an env var might change each time a command runs, or between terminal sessio
 Environment variables may duplicate the functionality of flags or configuration parameters, or they may be distinct from those things.
 See [Configuration](#configuration) for a breakdown of common types of configuration and recommendations on when environment variables are most appropriate.
 
-**For maximum portability, environment variable names must only contain letters, numbers, and underscores (and mustn't start with a number).**
-Which means `O_O` and `OwO` are the only emoticons that are also valid environment variable names.
+**For maximum portability, environment variable names must only contain uppercase letters, numbers, and underscores (and mustn't start with a number).**
+Which means `O_O` is the only emoticon that is also a valid environment variable name.
 
 **Aim for single-line environment variable values.**
 While multi-line values are possible, they create usability issues with the `env` command.


### PR DESCRIPTION
POSIX requires for environment variable to be all-uppercase: https://pubs.opengroup.org/onlinepubs/009696899/basedefs/xbd_chap08.html