### PR TITLE
Add docker pull multiple progress bars example

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -897,6 +897,20 @@ For example, `docker pull`’s multiple progress bars offer crucial insight into
 
 <!-- (TK docker pull animation) -->
 
+```
+$ docker image pull ruby
+Using default tag: latest
+latest: Pulling from library/ruby
+6c33745f49b4: Pull complete 
+ef072fc32a84: Extracting [================================================>  ]  7.569MB/7.812MB
+c0afb8e68e0b: Download complete 
+d599c07d28e6: Download complete 
+f2ecc74db11a: Downloading [=======================>                           ]  89.11MB/192.3MB
+3568445c8bf2: Download complete 
+b0efebc74f25: Downloading [===========================================>       ]  19.88MB/22.88MB
+9cb1ba6838a0: Download complete 
+```
+
 One thing to be aware of: hiding logs behind progress bars when things go _well_ makes it much easier for the user to understand what’s going on, but if there is an error, make sure you print out the logs.
 Otherwise, it will be very hard to debug.
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -895,8 +895,6 @@ Libraries like [tqdm](https://github.com/tqdm/tqdm) for Python and [schollz/prog
 The upside is that it can be a huge usability gain.
 For example, `docker pull`’s multiple progress bars offer crucial insight into what’s going on.
 
-<!-- (TK docker pull animation) -->
-
 ```
 $ docker image pull ruby
 Using default tag: latest


### PR DESCRIPTION
While an animated illustration will be great, when ready, for now this static snapshot of the progress bars can be helpful for readers who may not be using Docker and do not know what the article is talking about.

The example captures a good mix of states of various progress bars:

* The first layer is downloaded and extracted to complete the pull
* The second layer is in extraction stage
* A few layers are downloaded completely as concurrent and independent steps but are waiting for their sequential steps
* Two layers are still in their download phase with different percentages