### PR TITLE
Document FORCE_COLOR

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -1076,7 +1076,7 @@ Here’s a [list of POSIX standard env vars](https://pubs.opengroup.org/onlinepu
 
 **Check general-purpose environment variables for configuration values when possible:**
 
-- `NO_COLOR`, to disable color (see [Output](#output)).
+- `NO_COLOR`, to disable color (see [Output](#output)) or `FORCE_COLOR` to enable it and ignore the detection logic.
 - `DEBUG`, to enable more verbose output.
 - `EDITOR`, if you need to prompt the user to edit a file or input more than a single line.
 - `HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY` and `NO_PROXY`, if you’re going to perform network operations.


### PR DESCRIPTION
Document use of FORCE_COLOR variable which forces enablement of
coloring and ignore the detection logic.

There are other similar option used like CLI_COLOR, PY_COLORS but
that one is by far the most popular option. This complements
the NO_COLOR option with missed to cover for the opposite use-case
when it was designed.