### PR TITLE
ENH?: side-inform user to avoid exit codes above 127

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -273,7 +273,7 @@ Here are some that we like:
 
 **Return zero exit code on success, non-zero on failure.**
 Exit codes are how scripts determine whether a program succeeded or failed, so you should report this correctly.
-Map the non-zero exit codes to the most important failure modes.
+Map the non-zero exit codes to the most important failure modes, but avoid exit codes above 127.
 
 **Send output to `stdout`.**
 The primary output for your command should go to `stdout`.


### PR DESCRIPTION
More on rationale is elaborated at https://unix.stackexchange.com/a/99134/55543
and a quick possibly 'interesting' demo:

	$> bash -c 'exit 256'; echo $1
	0