### PR TITLE
Adding a CLI argument parser for Deno

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -265,6 +265,7 @@ Here are some that we like:
 * Haskell: [optparse-applicative](https://hackage.haskell.org/package/optparse-applicative)
 * Java: [picocli](https://picocli.info/)
 * Node: [oclif](https://oclif.io/)
+* Deno: [flags](https://deno.land/std/flags)
 * PHP: [console](https://github.com/symfony/console), [CLImate](https://climate.thephpleague.com)
 * Python: [Argparse](https://docs.python.org/3/library/argparse.html), [Click](https://click.palletsprojects.com/), [Typer](https://github.com/tiangolo/typer)
 * Ruby: [TTY](https://ttytoolkit.org/)


### PR DESCRIPTION
[Deno](https://deno.land) is a Javascript and TypeScript runtime, this pull request adds a link to a CLI argument parser (officially supported as it is part of Deno's standard library)