### PR TITLE
Add a CLI argument parser for Perl

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -265,6 +265,7 @@ Here are some that we like:
 * Haskell: [optparse-applicative](https://hackage.haskell.org/package/optparse-applicative)
 * Java: [picocli](https://picocli.info/)
 * Node: [oclif](https://oclif.io/)
+* Perl: [Getopt::Long](https://metacpan.org/pod/Getopt::Long)
 * PHP: [console](https://github.com/symfony/console), [CLImate](https://climate.thephpleague.com)
 * Python: [Argparse](https://docs.python.org/3/library/argparse.html), [Click](https://click.palletsprojects.com/), [Typer](https://github.com/tiangolo/typer)
 * Ruby: [TTY](https://ttytoolkit.org/)


### PR DESCRIPTION
Thanks for this set of guidelines --- it's clear that a lot of hard work has gone into the philosophy and guidelines!  Would you be willing to add Perl's standard argument parser to the list?  Thank you for considering this PR!