### PR TITLE
Args/flags: Use a cross-platform example for the set of default flags ls(1) might use if designed today

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -782,7 +782,7 @@ Here's a list of commonly used options:
 Making things configurable is good, but most users are not going to find the right flag and remember to use it all the time (or alias it).
 If it’s not the default, you’re making the experience worse for most of your users.
 
-For example, `ls` has terse default output to optimize for scripts and other historical reasons, but if it were designed today, it would probably default to `ls -lhFGT`.
+For example, `ls` has terse default output to optimize for scripts and other historical reasons, but if it were designed today, it would probably default to `ls -lhF`.
 
 **Prompt for user input.**
 If a user doesn’t pass an argument or flag, prompt for it.


### PR DESCRIPTION
Change the `ls -lhFGT` example to `ls -lhF`.  These flags are supported by macOS, Linux (GNU coreutils), NetBSD, and OpenBSD.  Details at <https://github.com/cli-guidelines/cli-guidelines/issues/39#issuecomment-984232908>.  Thanks for considering this PR!

Fixes #39.