### PR TITLE
Remove Rust library structopt

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -270,7 +270,7 @@ Here are some that we like:
 * PHP: [console](https://github.com/symfony/console), [CLImate](https://climate.thephpleague.com)
 * Python: [Argparse](https://docs.python.org/3/library/argparse.html), [Click](https://click.palletsprojects.com/), [Typer](https://github.com/tiangolo/typer)
 * Ruby: [TTY](https://ttytoolkit.org/)
-* Rust: [clap](https://clap.rs/), [structopt](https://github.com/TeXitoi/structopt)
+* Rust: [clap](https://clap.rs/)
 * Swift: [swift-argument-parser](https://github.com/apple/swift-argument-parser)
 
 **Return zero exit code on success, non-zero on failure.**


### PR DESCRIPTION
The functionality of `structopt` has been merged into `clap` a while ago. `structopt` itself is now in [maintenance mode](https://github.com/TeXitoi/structopt?tab=readme-ov-file#maintenance) for this reason.

For new projects, `clap` should be recommended.