### PR TITLE
Replace argument with flag in Arguments and flags section.

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -844,14 +844,14 @@ This can be very confusing for the user—especially given that one of the most 
 If possible, try to make both forms equivalent, although you might run up against the limitations of your argument parser.
 
 **Do not read secrets directly from flags.**
-When a command accepts a secret, e.g. via a `--password` argument,
-the argument value will leak the secret into `ps` output and potentially shell history.
+When a command accepts a secret, e.g. via a `--password` flag,
+the flag value will leak the secret into `ps` output and potentially shell history.
 And, this sort of flag encourages the use of insecure environment variables for secrets.
 
-Consider accepting sensitive data only via files, e.g. with a `--password-file` argument, or via `stdin`.
-A `--password-file` argument allows a secret to be passed in discreetly, in a wide variety of contexts.
+Consider accepting sensitive data only via files, e.g. with a `--password-file` flag, or via `stdin`.
+A `--password-file` flag allows a secret to be passed in discreetly, in a wide variety of contexts.
 
-(It’s possible to pass a file’s contents into an argument in Bash by using `--password $(< password.txt)`.
+(It’s possible to pass a file’s contents into a flag in Bash by using `--password $(< password.txt)`.
 This approach has the same security issue of leaking the file’s contents into the output of `ps`.
 It’s best avoided.)
 


### PR DESCRIPTION
Hello, 

Thanks for a great guide :heart: 

At the beginning of the [Arguments and Flags section](https://github.com/cli-guidelines/cli-guidelines/blob/main/content/_index.md?plain=1#L721), `flags` are defined as words with a hyphen or double hyphens at the start, while `arguments` are words without any hyphens. The terms were mixed up in the sentences, and _flag_ should be used instead of _argument_ since dashes are present.

This change will help maintain consistency in the terminology used.