### PR TITLE
replace the link for deno argparse library

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -267,7 +267,7 @@ Here are some that we like:
 * Julia: [ArgParse.jl](https://github.com/carlobaldassi/ArgParse.jl), [Comonicon.jl](https://github.com/comonicon/Comonicon.jl)
 * Kotlin: [clikt](https://ajalt.github.io/clikt/)
 * Node: [oclif](https://oclif.io/)
-* Deno: [flags](https://deno.land/std/flags)
+* Deno: [parseArgs](https://jsr.io/@std/cli/doc/parse-args/~/parseArgs)
 * Perl: [Getopt::Long](https://metacpan.org/pod/Getopt::Long)
 * PHP: [console](https://github.com/symfony/console), [CLImate](https://climate.thephpleague.com)
 * Python: [Argparse](https://docs.python.org/3/library/argparse.html), [Click](https://click.palletsprojects.com/), [Typer](https://github.com/tiangolo/typer)


### PR DESCRIPTION
Reason: The upstream added a warning about the module's depreciation in future releases in https://deno.land/std@0.224.0/flags/mod.ts