### PR TITLE
Fix invalid NO_COLOR guideline

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -635,7 +635,7 @@ These things should disable colors:
 
 - `stdout` or `stderr` is not an interactive terminal (a TTY).
   It’s best to individually check—if you’re piping `stdout` to another program, it’s still useful to get colors on `stderr`.
-- The `NO_COLOR` environment variable is set.
+- The `NO_COLOR` environment variable is set and it is not empty (regardless of its value).
 - The `TERM` environment variable has the value `dumb`.
 - The user passes the option `--no-color`.
 - You may also want to add a `MYAPP_NO_COLOR` environment variable in case users want to disable color specifically for your program.


### PR DESCRIPTION
The [no-color.org](https://no-color.org/) website states:

> Command-line software which adds ANSI color to its output by default
> should check for a NO_COLOR environment variable that, when present and
> not an empty string (regardless of its value), prevents the addition of
> ANSI color.

So, NO_COLOR does not only have to be set, but must also be non-empty.
Simply checking for its presence is non-compliant.

Signed-off-by: Manos Pitsidianakis <manos@pitsidianak.is>