### PR TITLE
Fix link to Rust library clap

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -272,7 +272,7 @@ Here are some that we like:
 * PHP: [console](https://github.com/symfony/console), [CLImate](https://climate.thephpleague.com)
 * Python: [Argparse](https://docs.python.org/3/library/argparse.html), [Click](https://click.palletsprojects.com/), [Typer](https://github.com/tiangolo/typer)
 * Ruby: [TTY](https://ttytoolkit.org/)
-* Rust: [clap](https://clap.rs/)
+* Rust: [clap](https://docs.rs/clap)
 * Swift: [swift-argument-parser](https://github.com/apple/swift-argument-parser)
 
 **Return zero exit code on success, non-zero on failure.**


### PR DESCRIPTION
The link for the Rust library [clap](https://docs.rs/clap) points to `https://clap.rs` which is now a parked domain. I chose to link to the Docs.rs page rather than clap's [GitHub page](https://github.com/clap-rs/clap) since it's pretty empty.