### PR TITLE
clarify security problem

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -855,7 +855,7 @@ Consider accepting sensitive data only via files, e.g. with a `--password-file` 
 A `--password-file` flag allows a secret to be passed in discreetly, in a wide variety of contexts.
 
 (It’s possible to pass a file’s contents into a flag in Bash by using `--password $(< password.txt)`.
-This approach has the same security as mentioned above.
+This approach has the same security problems mentioned above.
 It’s best avoided.)
 
 ### Interactivity {#interactivity}


### PR DESCRIPTION
in the discussion of passing passwords as flags, the statement "the same security as mentioned above" could be misread as an endorsement. this clarifies that it's discouraged