### PR TITLE
Add parser suggestions for C#

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -274,6 +274,7 @@ Here are some that we like:
 * Ruby: [TTY](https://ttytoolkit.org/)
 * Rust: [clap](https://docs.rs/clap)
 * Swift: [swift-argument-parser](https://github.com/apple/swift-argument-parser)
+* C#: [System.CommandLine](https://learn.microsoft.com/en-us/dotnet/standard/commandline/), [CommandLineParser](https://github.com/commandlineparser/commandline)
 
 **Return zero exit code on success, non-zero on failure.**
 Exit codes are how scripts determine whether a program succeeded or failed, so you should report this correctly.


### PR DESCRIPTION
Add two parser suggestions for C#:
- System.CommandLine: the standard parser from Microsoft. It is still in preview as of now but it is the one used for their internal tools such as the `dotnet` command itself.
- CommandLineParser: the most used third-party command line parser in the ecosystem