### PR TITLE
Replace deprecated resources.ToCSS with css.Sass

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -30,7 +30,7 @@
         gtag('config', 'G-DLXNEPQY85');
         </script>
 
-        {{ $css := resources.Get "css/main.css" | resources.ToCSS }}
+        {{ $css := resources.Get "css/main.css" | css.Sass }}
         <link rel="stylesheet" media="screen" href="/css/main.css">
         <link rel="stylesheet" media="print" href="/css/print.css">
     </head>

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "env": {
-      "HUGO_VERSION": "0.76.5"
+      "HUGO_VERSION": "0.128.0"
     }
   },
   "github": {


### PR DESCRIPTION
The local development server fails to start with Hugo v0.128.0+ due to the deprecated `resources.ToCSS` function. 

This change replaces it with `css.Sass` to fix the build error and allow `hugo server` to run successfully.