### PR TITLE
Fix sidebar overlapping content on iPad Mini landscape

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -128,7 +128,7 @@ body {
       overflow: auto;
    }
    main {
-      grid-column: 1 / 3;
+      grid-column: 2 / 3;
       grid-row: 1 / 2;
       box-sizing: border-box;
    }
@@ -256,12 +256,6 @@ body {
 
 main {
    padding: 0 1.7em;
-}
-
-@media (min-width: 901px) {
-   #command-line-interface-guidelines > section {
-      padding-left: 25%;
-   }
 }
 
 #command-line-interface-guidelines > h1 {


### PR DESCRIPTION
## Summary
- Fix sidebar overlapping main content on iPad Mini in landscape orientation
- Use separate grid columns instead of overlapping grid items with padding workaround
- Resolves iOS Safari rendering issues with the previous approach

## Test plan
- [ ] Test on iPad Mini in landscape orientation
- [ ] Verify sidebar no longer overlaps content
- [ ] Verify desktop layout still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)