### PR TITLE
Serve markdown at /llms.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .hugo_build.lock
 /public
 resources/
+.vercel/

--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,13 @@
 staticDir = ["assets"]
 
+[outputFormats.llmstxt]
+  baseName = "llms"
+  mediaType = "text/plain"
+  isPlainText = true
+
+[outputs]
+  home = ["HTML", "RSS", "llmstxt"]
+
 [markup]
   [markup.goldmark]
     [markup.goldmark.renderer]

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -7,6 +7,7 @@
         <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
         <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
         <link rel="manifest" href="/site.webmanifest">
+        <link rel="alternate" type="text/markdown" href="/llms.txt">
 
         <title>Command Line Interface Guidelines</title>
         <meta name="twitter:card" content="summary_large_image">

--- a/layouts/index.llmstxt.txt
+++ b/layouts/index.llmstxt.txt
@@ -1,0 +1,1 @@
+{{ .RawContent }}

--- a/vercel-build.sh
+++ b/vercel-build.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Post-build step for Vercel: packages Hugo output using the Build Output API.
+# We use this instead of vercel.json routes because Build Output API routes
+# run before static file serving, which lets us content-negotiate on /
+# (vercel.json rewrites run after, so index.html always wins).
+set -e
+
+# Copy Hugo's output into the Build Output API structure
+mkdir -p .vercel/output/static
+cp -r public/* .vercel/output/static/
+
+# Define routes that run before static file serving
+cat > .vercel/output/config.json << 'EOF'
+{
+  "version": 3,
+  "routes": [
+    {
+      "src": "^/$",
+      "has": [{ "type": "header", "key": "accept", "value": "text/markdown" }],
+      "dest": "/llms.txt",
+      "headers": { "Content-Type": "text/markdown; charset=utf-8" }
+    },
+    {
+      "src": "^/llms\\.txt$",
+      "headers": { "Content-Type": "text/markdown; charset=utf-8" },
+      "continue": true
+    }
+  ]
+}
+EOF

--- a/vercel.json
+++ b/vercel.json
@@ -4,6 +4,7 @@
       "HUGO_VERSION": "0.128.0"
     }
   },
+  "buildCommand": "hugo && bash vercel-build.sh",
   "github": {
     "silent": true
   }


### PR DESCRIPTION
## Summary
- Generate `/llms.txt` from homepage markdown using a Hugo custom output format
- Serve it with `Content-Type: text/markdown` via Vercel headers
- Content-negotiate on `/` — requests with `Accept: text/markdown` get the markdown version (rewrite, not redirect)
- Link to the markdown version from the HTML `<head>` with `<link rel="alternate">`

## Test plan
- [ ] `hugo` builds and `public/llms.txt` contains the raw markdown content
- [ ] Deployed `/llms.txt` returns markdown with correct content type
- [ ] `curl -H 'Accept: text/markdown' https://clig.dev/` returns the markdown content
- [ ] HTML source includes `<link rel="alternate" type="text/markdown" href="/llms.txt">`

🤖 Generated with [Claude Code](https://claude.com/claude-code)